### PR TITLE
更改模型记忆存储方式

### DIFF
--- a/local_helper_client/src/main/java/com/ai/controller/AiController.java
+++ b/local_helper_client/src/main/java/com/ai/controller/AiController.java
@@ -13,12 +13,16 @@ import com.ai.utils.MessageFilter;
 import com.ai.utils.MemoryStorage;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import io.modelcontextprotocol.client.McpAsyncClient;
+import org.apache.poi.ss.formula.functions.T;
 import org.reactivestreams.Subscription;
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClientResponse;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.messages.*;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.content.Media;
 import org.springframework.ai.mcp.AsyncMcpToolCallbackProvider;
@@ -32,11 +36,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 //import static org.springframework.ai.chat.client.advisor.AbstractChatMemoryAdvisor.CHAT_MEMORY_CONVERSATION_ID_KEY;
 
@@ -164,12 +171,17 @@ public class AiController {
         return response.doOnNext(assistantResponse::append) // 追加到响应收集器中
 //                .doOnSubscribe(sub -> activeSubscriptions.put(request.getChatId(), sub)) // 直接存储Subscription
                 .doFinally(Message->{
+                    //TODO 从响应中获取AssistantMessage以及ToolResponseMessage并存储
                     //将响应信息存储到数据库
                     String type = "assistant"; //后续寻找如何获取响应类型
                     //将用户信息保存到数据库
-                    saveChatHistory(request.getChatId(),"user", finalUserMessage);
+                    saveChatHistory(request.getChatId(),"user", new UserMessage(finalUserMessage));
                     //将响应信息存储到数据库
-                    saveChatHistory(request.getChatId(),type, assistantResponse.toString());
+                    saveChatHistory(request.getChatId(),type, new AssistantMessage(assistantResponse.toString()));
+//                    List<ToolResponseMessage> toolMessage = chatMemory.get(request.getChatId()).stream().filter(message -> message.getMessageType().equals(MessageType.TOOL)).filter(message -> message instanceof ToolResponseMessage).map(message -> (ToolResponseMessage)message).toList();
+//                    saveChatHistory(request.getChatId(),"tool", toolMessage);
+//                    Flux<AssistantMessage> assistantMessageFlux = chatClient.prompt().stream().chatClientResponse().map(chatClientResponse -> chatClientResponse.chatResponse().getResult().getOutput());
+//                    Mono<List<AssistantMessage>> listMono = assistantMessageFlux.collectList();
                 });
     }
 
@@ -235,14 +247,15 @@ public class AiController {
 
 
     //将会话信息存储到数据库
-    public void saveChatHistory(String chatId, String type,  String content) {
-        ChatDetail chatDetail = new ChatDetail();
-        chatDetail.setChatId(chatId);
-        chatDetail.setMessageType(type);
-        chatDetail.setContent(content);
-        chatDetailMapper.insert(chatDetail);
+    public void saveChatHistory(String chatId, String type, Message content) {
+        chatHistoryService.saveChatDetail(chatId, type, content);
     }
 
+    public void saveChatHistory(String chatId, String type,  List<? extends Message> content) {
+        for (Message message : content) {
+            this.saveChatHistory(chatId, type, message);
+        }
+    }
 
     @Autowired
     private ModelMessageService modelMessageService;

--- a/local_helper_client/src/main/java/com/ai/service/ChatHistoryService.java
+++ b/local_helper_client/src/main/java/com/ai/service/ChatHistoryService.java
@@ -1,6 +1,8 @@
 package com.ai.service;
 
+import com.ai.model.po.Chat;
 import com.ai.model.vo.ChatListVo;
+import org.springframework.ai.chat.messages.Message;
 
 import java.util.List;
 
@@ -12,9 +14,15 @@ public interface ChatHistoryService {
     //获取会话id列表
     List<ChatListVo> getChatIds(String type);
 
+    //获取会话
+    ChatListVo getChatId(String chatId);
+
     //删除会话记录
     void deleteChatId(String type, String chatId);
 
     //更新会话信息
     void updateChatId(ChatListVo chatListVo);
+
+    //保存会话详情
+    void saveChatDetail(String chatId, String type, Message content);
 }

--- a/local_helper_client/src/main/java/com/ai/service/impl/InMemoryChatHistoryServiceImpl.java
+++ b/local_helper_client/src/main/java/com/ai/service/impl/InMemoryChatHistoryServiceImpl.java
@@ -11,8 +11,10 @@ import com.ai.utils.MessageFilter;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.conditions.query.LambdaQueryChainWrapper;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
@@ -160,8 +162,8 @@ public class InMemoryChatHistoryServiceImpl implements ChatHistoryService {
         }
         //工具类型特殊处理
         //判断是否存在
-        List<ChatDetail> chatDetails = chatDetailMapper.selectList(new LambdaQueryWrapper<ChatDetail>().eq(ChatDetail::getChatId, chatId).eq(ChatDetail::getMessageType, type));
-        ToolResponseMessage toolResponseMessage = (ToolResponseMessage) content;
+//        List<ChatDetail> chatDetails = chatDetailMapper.selectList(new LambdaQueryWrapper<ChatDetail>().eq(ChatDetail::getChatId, chatId).eq(ChatDetail::getMessageType, type));
+//        ToolResponseMessage toolResponseMessage = (ToolResponseMessage) content;
 //        new ToolResponseMessage(new ToolResponseMessage.ToolResponse())
     }
 }

--- a/local_helper_client/src/main/java/com/ai/socket/WebSocketServer.java
+++ b/local_helper_client/src/main/java/com/ai/socket/WebSocketServer.java
@@ -10,6 +10,7 @@ import jakarta.websocket.OnOpen;
 import jakarta.websocket.Session;
 import jakarta.websocket.server.PathParam;
 import jakarta.websocket.server.ServerEndpoint;
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
@@ -102,7 +103,7 @@ public class WebSocketServer {
                                 session.getBasicRemote().sendText("{\"chat\":\"服务繁忙,请稍后再试\"}");
                                 session.getBasicRemote().sendText("<end>");
                                 //每次响应完成后，调用方法将消息保存到数据库中
-                                aiController.saveChatHistory(request.getChatId(), "assistant", "服务繁忙,请稍后再试");
+                                aiController.saveChatHistory(request.getChatId(), "assistant", new AssistantMessage("服务繁忙,请稍后再试"));
                             } catch (IOException e) {
                                 e.printStackTrace();
                             }


### PR DESCRIPTION
The current change is only temporary, and the effect should be to get a different Message type from each response, and then get the toolcall information from the AssistantMessage and store it in the ToolResponseMessage and store it in the database. Finally, when loading, match the corresponding ToolResponseMessage according to the Toolcall id of the AssistantMessage, and load it into the chatMemory.
The problem now is how to get the AssistantMessage in its entirety from the streaming response